### PR TITLE
Refactor favorites

### DIFF
--- a/client/src/components/SetItem.jsx
+++ b/client/src/components/SetItem.jsx
@@ -23,7 +23,7 @@ const SetItem = ({ set, setOwner, onDelete }) => {
         <h2>{set.title}</h2>
       </Link>
       <div className="set-item-right">
-        <Button variant="link" onClick={() => toggleLike(set.id)}>
+        <Button variant="link" onClick={() => toggleLike(set)}>
           {isLiked ? (
             <FontAwesomeIcon
               icon={fillHeart}

--- a/client/src/context/UserProvider.jsx
+++ b/client/src/context/UserProvider.jsx
@@ -66,14 +66,14 @@ const UserProvider = (props) => {
     setFavoriteSets((prev) => [...prev, newSet]);
   };
 
-  const removeDeletedFromFavList = (setId) =>
+  const removeFromFavList = (setId) =>
     setFavoriteSets((prevSet) => prevSet.filter((set) => set.id !== setId));
 
   const userData = {
     user,
     favoriteSets,
     addToFavList,
-    removeDeletedFromFavList,
+    removeFromFavList,
     logout,
     storeUserInfo,
     clearUserInfo,

--- a/client/src/context/UserProvider.jsx
+++ b/client/src/context/UserProvider.jsx
@@ -17,9 +17,24 @@ const UserProvider = (props) => {
 
   useEffect(() => {
     if (user) {
-      updateFavoriteSets();
+      axios
+        .get("/api/favorites")
+        .then((res) => {
+          setFavoriteSets(res.data);
+        })
+        .catch((err) => {
+          if (err.response.status === 401) {
+            clearUserInfo();
+          } else {
+            console.error(err);
+          }
+        });
     }
   }, [user]);
+
+  useEffect(() => {
+    localStorage.setItem("favoriteSets", JSON.stringify(favoriteSets));
+  }, [favoriteSets]);
 
   /**
    * store the userObject in state and local storage
@@ -45,20 +60,10 @@ const UserProvider = (props) => {
     });
   };
 
-  const updateFavoriteSets = () => {
-    axios
-      .get("/api/favorites")
-      .then((res) => {
-        setFavoriteSets(res.data);
-        localStorage.setItem("favoriteSets", JSON.stringify(res.data));
-      })
-      .catch((err) => {
-        if (err.response.status === 401) {
-          clearUserInfo();
-        } else {
-          console.error(err);
-        }
-      });
+  const addToFavList = (set) => {
+    const { id, title, user_id, username, private: isPrivate } = set;
+    const newSet = { id, title, user_id, username, private: isPrivate };
+    setFavoriteSets((prev) => [...prev, newSet]);
   };
 
   const removeDeletedFromFavList = (setId) =>
@@ -67,7 +72,7 @@ const UserProvider = (props) => {
   const userData = {
     user,
     favoriteSets,
-    updateFavoriteSets,
+    addToFavList,
     removeDeletedFromFavList,
     logout,
     storeUserInfo,

--- a/client/src/hooks/useFavButton.jsx
+++ b/client/src/hooks/useFavButton.jsx
@@ -5,16 +5,16 @@ import { toast } from "react-toastify";
 
 const useFavButton = (initialState = false) => {
   const [isLiked, setIsLiked] = useState(initialState);
-  const { updateFavoriteSets, clearUserInfo } = useUser();
+  const { addToFavList, removeDeletedFromFavList, clearUserInfo } = useUser();
 
-  const toggleLike = (setId) => {
+  const toggleLike = (set) => {
     if (isLiked) {
       // Unlike a set
       axios
-        .delete(`/api/favorites/${setId}`)
+        .delete(`/api/favorites/${set.id}`)
         .then(({ status }) => {
           if (status === 200) {
-            updateFavoriteSets();
+            removeDeletedFromFavList(set.id);
             setIsLiked(false);
           }
         })
@@ -29,10 +29,10 @@ const useFavButton = (initialState = false) => {
     } else {
       // Like a set
       axios
-        .post(`/api/favorites/${setId}`)
+        .post(`/api/favorites/${set.id}`)
         .then(({ status }) => {
           if (status === 201) {
-            updateFavoriteSets();
+            addToFavList(set);
             setIsLiked(true);
           }
         })

--- a/client/src/hooks/useFavButton.jsx
+++ b/client/src/hooks/useFavButton.jsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 
 const useFavButton = (initialState = false) => {
   const [isLiked, setIsLiked] = useState(initialState);
-  const { addToFavList, removeDeletedFromFavList, clearUserInfo } = useUser();
+  const { addToFavList, removeFromFavList, clearUserInfo } = useUser();
 
   const toggleLike = (set) => {
     if (isLiked) {
@@ -14,7 +14,7 @@ const useFavButton = (initialState = false) => {
         .delete(`/api/favorites/${set.id}`)
         .then(({ status }) => {
           if (status === 200) {
-            removeDeletedFromFavList(set.id);
+            removeFromFavList(set.id);
             setIsLiked(false);
           }
         })

--- a/client/src/hooks/useSetsList.jsx
+++ b/client/src/hooks/useSetsList.jsx
@@ -1,11 +1,11 @@
-import { toast } from "react-toastify";
-import { useUser } from "../context/UserProvider";
-import axios from "axios";
 import { useState } from "react";
+import { useUser } from "../context/UserProvider";
+import { toast } from "react-toastify";
+import axios from "axios";
 
 const useSetsList = () => {
   const [sets, setSets] = useState([]);
-  const { clearUserInfo, removeDeletedFromFavList } = useUser();
+  const { clearUserInfo, removeFromFavList } = useUser();
 
   const deleteSet = (setId) => {
     axios
@@ -14,7 +14,7 @@ const useSetsList = () => {
         if (res.status === 200) {
           const updatedSets = sets.filter((set) => set.id !== setId);
           setSets(updatedSets);
-          removeDeletedFromFavList(setId);
+          removeFromFavList(setId);
           toast.success(res.data.message);
         }
       })

--- a/client/src/routes/ViewSet.jsx
+++ b/client/src/routes/ViewSet.jsx
@@ -17,7 +17,7 @@ const ViewSet = () => {
   const { setId } = useParams();
   const { user, favoriteSets } = useUser();
   const { isLiked, checkLiked, toggleLike } = useFavButton();
-  
+
   const [setData, setSetData] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -83,7 +83,7 @@ const ViewSet = () => {
           <h1>{set.title}</h1>
           <h2>{set.category_name}</h2>
           {user && (
-            <Button variant="link" onClick={() => toggleLike(setId)}>
+            <Button variant="link" onClick={() => toggleLike(set)}>
               {isLiked ? (
                 <FontAwesomeIcon
                   icon={fillHeart}

--- a/server/db/queries/favorites.js
+++ b/server/db/queries/favorites.js
@@ -4,7 +4,8 @@ const getFavoritesByUserId = (userId) => {
   return db
     .query(
       `
-    SELECT sets.*, users.username FROM favorites
+    SELECT sets.id, sets.title, sets.private, sets.user_id, users.username AS username
+    FROM favorites
     JOIN sets ON favorites.set_id = sets.id
     JOIN users ON sets.user_id = users.id
     WHERE favorites.user_id = $1 


### PR DESCRIPTION
- Favorite sets are fetched only once upon user log in
- Any subsequent likes/ unlikes are maintained on the frontend to save load time and avoid re-fetching the whole favourite list every time a set is liked/ unliked